### PR TITLE
Add PurgeCSS Plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,6 +33,12 @@ module.exports = {
         },
         update: process.env.GATSBY_UPDATE_SCHEMA_SNAPSHOT
       }
+    },
+    {
+      resolve: `gatsby-plugin-purgecss`,
+      options: {
+        develop: true
+      }
     }
   ]
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const slugifyOptions = {
   lower: true,
-  remove: /[*+~.()'"!:@#\,]/g
+  remove: /[^a-zA-Z\d]/g
 };
 
 exports.onCreateNode = ({ node, actions }) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const slugifyOptions = {
   lower: true,
-  remove: /[*+~.()'"!:@]/g
+  remove: /[*+~.()'"!:@#\,]/g
 };
 
 exports.onCreateNode = ({ node, actions }) => {
@@ -15,8 +15,6 @@ exports.onCreateNode = ({ node, actions }) => {
     const stateSlug = state && slugify(state, slugifyOptions);
     const citySlug = city && slugify(city, slugifyOptions);
     const branchSlug = branch && slugify(branch, slugifyOptions);
-
-    // const slug = `${bankSlug}/${stateSlug}/${citySlug}/${branchSlug}-branch`;
 
     let slug = "";
     if (bankSlug) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8380,6 +8380,16 @@
         "micromatch": "^3.1.10"
       }
     },
+    "gatsby-plugin-purgecss": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-purgecss/-/gatsby-plugin-purgecss-4.0.1.tgz",
+      "integrity": "sha512-sYh7gm+9dovl+QASrInSXqB2qIMdfGW+Y7+Gum//jYjvktYlFCjGUXD8k/Wiw+CmXaJh8k5avFC23Cot96SS4w==",
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "loader-utils": "^1.1.0",
+        "purgecss": "^1.3.0"
+      }
+    },
     "gatsby-plugin-sass": {
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sass/-/gatsby-plugin-sass-2.1.26.tgz",
@@ -12960,6 +12970,84 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "purgecss": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-1.4.2.tgz",
+      "integrity": "sha512-hkOreFTgiyMHMmC2BxzdIw5DuC6kxAbP/gGOGd3MEsF3+5m69rIvUEPaxrnoUtfODTFKe9hcXjGwC6jcjoyhOw==",
+      "requires": {
+        "glob": "^7.1.3",
+        "postcss": "^7.0.14",
+        "postcss-selector-parser": "^6.0.0",
+        "yargs": "^14.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
+          "integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "q": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "bulma": "^0.8.0",
     "gatsby": "^2.18.25",
+    "gatsby-plugin-purgecss": "^4.0.1",
     "gatsby-plugin-sass": "^2.1.26",
     "gatsby-plugin-schema-snapshot": "^1.0.0",
     "gatsby-plugin-typescript": "^2.1.23",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "license": "MIT",
   "scripts": {
-    "build": "npm run make-data && gatsby build",
+    "build": "npm run make-data && NODE_OPTIONS=\"--max-old-space-size=4096\" gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",


### PR DESCRIPTION
So with the current setup, we end up building HTML pages that are too large because they include all styles from the imported SCSS files from Bulma. Each HTML file is about 128KB and the entire site comes to about 19GB. It runs out of space on Zeit Now (free tier) 😱 

PurgeCSS removes the unused CSS styles and there's a [Gatsby plugin](https://github.com/anantoghosh/gatsby-plugin-purgecss) to easily plug this into the Gatsby build process.

After including PurgeCSS, individual HTML file size is about 5KB 🎉  and the entire site is about 1.7GB 🎉 🎉 